### PR TITLE
technic: no forceload of switching stations

### DIFF
--- a/technic_modpack/technic/depends.txt
+++ b/technic_modpack/technic/depends.txt
@@ -12,3 +12,4 @@ intllib?
 unified_inventory?
 vector_extras?
 dye?
+monitoring?

--- a/technic_modpack/technic/machines/init.lua
+++ b/technic_modpack/technic/machines/init.lua
@@ -8,6 +8,8 @@ dofile(path.."/MV/init.lua")
 dofile(path.."/HV/init.lua")
 
 dofile(path.."/switching_station.lua")
+dofile(path.."/switching_station_globalstep.lua")
+
 dofile(path.."/power_monitor.lua")
 dofile(path.."/supply_converter.lua")
 

--- a/technic_modpack/technic/machines/switching_station.lua
+++ b/technic_modpack/technic/machines/switching_station.lua
@@ -241,12 +241,7 @@ local function run_nodes(list, run_stage)
 	end
 end
 
-minetest.register_abm({
-	nodenames = {"technic:switching_station"},
-	label = "Switching Station", -- allows the mtt profiler to profile this abm individually
-	interval   = 1,
-	chance     = 1,
-	action = function(pos, node, active_object_count, active_object_count_wider)
+technic.switching_station_run = function(pos)
 		if not technic.powerctrl_state then return end
 		local meta             = minetest.get_meta(pos)
 		local meta1            = nil
@@ -267,9 +262,6 @@ minetest.register_abm({
 
 		--Disable if necessary
 		if meta:get_int("active") ~= 1 then
-			minetest.forceload_free_block(pos)
-			minetest.forceload_free_block(pos1)
-			meta:set_int('is_forceloaded', 0)
 			meta:set_string("infotext",S("%s Already Present"):format(machine_name))
 
 			local poshash = minetest.hash_node_position(pos)
@@ -284,19 +276,10 @@ minetest.register_abm({
 		local name = minetest.get_node(pos1).name
 		local tier = technic.get_cable_tier(name)
 		if tier then
-			-- Forceload switching station
-			if meta:get_int('is_forceloaded') ~= 1 then
-			    minetest.forceload_block(pos)
-			    minetest.forceload_block(pos1)
-			    meta:set_int('is_forceloaded', 1)
-			end
 			PR_nodes, BA_nodes, RE_nodes = get_network(pos, pos1, tier)
 		else
 			--dprint("Not connected to a network")
 			meta:set_string("infotext", S("%s Has No Network"):format(machine_name))
-			minetest.forceload_free_block(pos)
-			minetest.forceload_free_block(pos1)
-			meta:set_int('is_forceloaded', 0)
 			return
 		end
 
@@ -448,8 +431,8 @@ minetest.register_abm({
 			meta1:set_int(eu_input_str, 0)
 		end
 
-	end,
-})
+end
+
 
 -- Timeout ABM
 -- Timeout for a node in case it was disconnected from the network

--- a/technic_modpack/technic/machines/switching_station_globalstep.lua
+++ b/technic_modpack/technic/machines/switching_station_globalstep.lua
@@ -1,0 +1,136 @@
+local has_monitoring_mod = minetest.get_modpath("monitoring")
+
+local switches = {} -- pos_hash -> { time = time_us }
+
+local function get_switch_data(pos)
+	local hash = minetest.hash_node_position(pos)
+	local switch = switches[hash]
+
+	if not switch then
+		switch = {
+			time = 0,
+			skip = 0
+		}
+		switches[hash] = switch
+	end
+
+	return switch
+end
+
+local active_switching_stations_metric, switching_stations_usage_metric
+
+if has_monitoring_mod then
+	active_switching_stations_metric = monitoring.gauge(
+		"technic_active_switching_stations",
+		"Number of active switching stations"
+	)
+
+	switching_stations_usage_metric = monitoring.counter(
+		"technic_switching_stations_usage",
+		"usage in microseconds cpu time"
+	)
+end
+
+-- collect all active switching stations
+minetest.register_abm({
+	nodenames = {"technic:switching_station"},
+	label = "Switching Station",
+	interval   = 1,
+	chance     = 1,
+	action = function(pos)
+		local switch = get_switch_data(pos)
+		switch.time = minetest.get_us_time()
+	end
+})
+
+
+-- the interval between technic_run calls
+local technic_run_interval = 1.0
+
+-- iterate over all collected switching stations and execute the technic_run function
+local timer = 0
+minetest.register_globalstep(function(dtime)
+	timer = timer + dtime
+	if timer < technic_run_interval then
+		return
+	end
+	timer = 0
+
+	local now = minetest.get_us_time()
+
+	local off_delay_seconds = tonumber(minetest.settings:get("technic.switch.off_delay_seconds") or "300")
+	local off_delay_micros = off_delay_seconds*1000*1000
+
+	local active_switches = 0
+
+	for hash, switch in pairs(switches) do
+		local pos = minetest.get_position_from_hash(hash)
+		local diff = now - switch.time
+
+		minetest.get_voxel_manip(pos, pos)
+		local node = minetest.get_node(pos)
+
+		if node.name ~= "technic:switching_station" then
+			-- station vanished
+			switches[hash] = nil
+
+		elseif diff < off_delay_micros then
+			-- station active
+			active_switches = active_switches + 1
+
+			if switch.skip < 1 then
+
+				local start = minetest.get_us_time()
+				technic.switching_station_run(pos)
+				local switch_diff = minetest.get_us_time() - start
+
+
+				local meta = minetest.get_meta(pos)
+
+				-- overload detection
+				if switch_diff > 250000 then
+					switch.skip = 30
+				elseif switch_diff > 150000 then
+					switch.skip = 20
+				elseif switch_diff > 75000 then
+					switch.skip = 10
+				elseif switch_diff > 50000 then
+					switch.skip = 2
+				end
+
+				if switch.skip > 0 then
+					local efficiency = math.floor(1/switch.skip*100)
+					meta:set_string("infotext", "Polyfuse triggered, current efficiency: " ..
+						efficiency .. "% generated lag : " .. math.floor(switch_diff/1000) .. " ms")
+				end
+
+			else
+				switch.skip = math.max(switch.skip - 1, 0)
+			end
+
+
+		else
+			-- station timed out
+			switches[hash] = nil
+
+		end
+	end
+
+	local time_usage = minetest.get_us_time() - now
+
+	if has_monitoring_mod then
+		active_switching_stations_metric.set(active_switches)
+		switching_stations_usage_metric.inc(time_usage)
+	end
+
+
+end)
+
+
+minetest.register_chatcommand("technic_flush_switch_cache", {
+	description = "removes all loaded switching stations from the cache",
+	privs = { server = true },
+	func = function()
+		switches = {}
+	end
+})

--- a/technic_modpack/technic/mod.conf
+++ b/technic_modpack/technic/mod.conf
@@ -1,3 +1,3 @@
 name = technic
 depends = default, pipeworks, technic_worldgen, basic_materials
-optional_depends = bucket, screwdriver, mesecons, mesecons_mvps, digilines, digiline_remote, intllib, unified_inventory, vector_extras, dye
+optional_depends = bucket, screwdriver, mesecons, mesecons_mvps, digilines, digiline_remote, intllib, unified_inventory, vector_extras, dye, monitoring


### PR DESCRIPTION
use patch from Pandorabox to disable forceloading and use globalstep instead of abm